### PR TITLE
Upgraded vagrant to 1.2.2; 

### DIFF
--- a/testing/ssh.sh
+++ b/testing/ssh.sh
@@ -3,7 +3,7 @@
 cd $(dirname $0)/vm
 PORT=$(vagrant ssh-config | grep Port | awk '{print $2}')
 USER=$(vagrant ssh-config | grep 'User ' | awk '{print $2}')
-KEY=$(vagrant ssh-config | grep IdentityFile | awk '{print $2}')
+KEY=$(vagrant ssh-config | grep IdentityFile | awk '{print $2}' | sed -e 's/^"//'  -e 's/"$//')
 HOST=$(vagrant ssh-config | grep HostName | awk '{print $2}')
 
-ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i $KEY -p $PORT $USER@$HOST $@
+ssh -q -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i "$KEY" -p $PORT $USER@$HOST $@

--- a/testing/vm/Vagrantfile
+++ b/testing/vm/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant::Config.run do |config|
   config.vm.box = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
-  config.vm.network "33.33.33.10"
+  config.vm.network :hostonly, "33.33.33.10"
 
   config.vm.provision :puppet do |puppet|
     puppet.manifests_path = "manifests"


### PR DESCRIPTION
also fixed a bug that when vagrant ssh-config prints quoted string for IdentityFile, the quotes are passed into ssh command, which results in wrong filename.
